### PR TITLE
Remove redundant Async client prefixes

### DIFF
--- a/amodbus/client/__init__.py
+++ b/amodbus/client/__init__.py
@@ -1,15 +1,15 @@
 """Client."""
 
 __all__ = [
-    "AsyncModbusSerialClient",
-    "AsyncModbusTcpClient",
-    "AsyncModbusTlsClient",
-    "AsyncModbusUdpClient",
+    "ModbusSerialClient",
+    "ModbusTcpClient",
+    "ModbusTlsClient",
+    "ModbusUdpClient",
     "ModbusBaseClient",
 ]
 
 from amodbus.client.base import ModbusBaseClient
-from amodbus.client.serial import AsyncModbusSerialClient
-from amodbus.client.tcp import AsyncModbusTcpClient
-from amodbus.client.tls import AsyncModbusTlsClient
-from amodbus.client.udp import AsyncModbusUdpClient
+from amodbus.client.serial import ModbusSerialClient
+from amodbus.client.tcp import ModbusTcpClient
+from amodbus.client.tls import ModbusTlsClient
+from amodbus.client.udp import ModbusUdpClient

--- a/amodbus/client/serial.py
+++ b/amodbus/client/serial.py
@@ -15,8 +15,8 @@ with contextlib.suppress(ImportError):
     import serial
 
 
-class AsyncModbusSerialClient(ModbusBaseClient):
-    """**AsyncModbusSerialClient**.
+class ModbusSerialClient(ModbusBaseClient):
+    """**ModbusSerialClient**.
 
     Fixed parameters:
 
@@ -49,10 +49,10 @@ class AsyncModbusSerialClient(ModbusBaseClient):
 
     Example::
 
-        from amodbus.client import AsyncModbusSerialClient
+        from amodbus.client import ModbusSerialClient
 
         async def run():
-            client = AsyncModbusSerialClient("dev/serial0")
+            client = ModbusSerialClient("dev/serial0")
 
             await client.connect()
             ...

--- a/amodbus/client/tcp.py
+++ b/amodbus/client/tcp.py
@@ -10,8 +10,8 @@ from amodbus.pdu import ModbusPDU
 from amodbus.transport import CommParams, CommType
 
 
-class AsyncModbusTcpClient(ModbusBaseClient):
-    """**AsyncModbusTcpClient**.
+class ModbusTcpClient(ModbusBaseClient):
+    """**ModbusTcpClient**.
 
     Fixed parameters:
 
@@ -41,10 +41,10 @@ class AsyncModbusTcpClient(ModbusBaseClient):
 
     Example::
 
-        from amodbus.client import AsyncModbusTcpClient
+        from amodbus.client import ModbusTcpClient
 
         async def run():
-            client = AsyncModbusTcpClient("localhost")
+            client = ModbusTcpClient("localhost")
 
             await client.connect()
             ...

--- a/amodbus/client/tls.py
+++ b/amodbus/client/tls.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import ssl
 from collections.abc import Callable
 
-from amodbus.client.tcp import AsyncModbusTcpClient
+from amodbus.client.tcp import ModbusTcpClient
 from amodbus.framer import FramerType
 from amodbus.pdu import ModbusPDU
 from amodbus.transport import CommParams, CommType
 
 
-class AsyncModbusTlsClient(AsyncModbusTcpClient):
-    """**AsyncModbusTlsClient**.
+class ModbusTlsClient(ModbusTcpClient):
+    """**ModbusTlsClient**.
 
     Fixed parameters:
 
@@ -43,10 +43,10 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
 
     Example::
 
-        from amodbus.client import AsyncModbusTlsClient
+        from amodbus.client import ModbusTlsClient
 
         async def run():
-            client = AsyncModbusTlsClient("localhost")
+            client = ModbusTlsClient("localhost")
 
             await client.connect()
             ...
@@ -86,7 +86,7 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
             reconnect_delay_max=reconnect_delay_max,
             timeout_connect=timeout,
         )
-        AsyncModbusTcpClient.__init__(
+        ModbusTcpClient.__init__(
             self,
             "",
             framer=framer,

--- a/amodbus/client/udp.py
+++ b/amodbus/client/udp.py
@@ -13,8 +13,8 @@ from amodbus.transport import CommParams, CommType
 DGRAM_TYPE = socket.SOCK_DGRAM
 
 
-class AsyncModbusUdpClient(ModbusBaseClient):
-    """**AsyncModbusUdpClient**.
+class ModbusUdpClient(ModbusBaseClient):
+    """**ModbusUdpClient**.
 
     Fixed parameters:
 
@@ -44,10 +44,10 @@ class AsyncModbusUdpClient(ModbusBaseClient):
 
     Example::
 
-        from amodbus.client import AsyncModbusUdpClient
+        from amodbus.client import ModbusUdpClient
 
         async def run():
-            client = AsyncModbusUdpClient("localhost")
+            client = ModbusUdpClient("localhost")
 
             await client.connect()
             ...

--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -145,16 +145,16 @@ Asynchronous example
 
 ::
 
-    from amodbus.client import AsyncModbusTcpClient
+    from amodbus.client import ModbusTcpClient
 
-    client = AsyncModbusTcpClient('MyDevice.lan')    # Create client object
+    client = ModbusTcpClient('MyDevice.lan')    # Create client object
     await client.connect()                           # connect to device, reconnect automatically
     await client.write_coil(1, True, slave=1)        # set information in device
     result = await client.read_coils(2, 3, slave=1)  # get information from device
     print(result.bits[0])                            # use information
     client.close()                                   # Disconnect device
 
-The line :mod:`client = AsyncModbusTcpClient('MyDevice.lan')` only creates the object; it does not activate
+The line :mod:`client = ModbusTcpClient('MyDevice.lan')` only creates the object; it does not activate
 anything.
 
 The line :mod:`await client.connect()` connects to the device (or comm port), if this cannot connect successfully within
@@ -245,16 +245,16 @@ There are a client class for each type of communication and for asynchronous/syn
 .. list-table::
 
    * - **Serial**
-     - :mod:`AsyncModbusSerialClient`
+     - :mod:`ModbusSerialClient`
      - :mod:`ModbusSerialClient`
    * - **TCP**
-     - :mod:`AsyncModbusTcpClient`
+     - :mod:`ModbusTcpClient`
      - :mod:`ModbusTcpClient`
    * - **TLS**
-     - :mod:`AsyncModbusTlsClient`
+     - :mod:`ModbusTlsClient`
      - :mod:`ModbusTlsClient`
    * - **UDP**
-     - :mod:`AsyncModbusUdpClient`
+     - :mod:`ModbusUdpClient`
      - :mod:`ModbusUdpClient`
 
 Client common
@@ -273,7 +273,7 @@ Some methods are common to all clients:
 
 Client serial
 ^^^^^^^^^^^^^
-.. autoclass:: amodbus.client.AsyncModbusSerialClient
+.. autoclass:: amodbus.client.ModbusSerialClient
     :members:
     :member-order: bysource
     :show-inheritance:
@@ -285,7 +285,7 @@ Client serial
 
 Client TCP
 ^^^^^^^^^^
-.. autoclass:: amodbus.client.AsyncModbusTcpClient
+.. autoclass:: amodbus.client.ModbusTcpClient
     :members:
     :member-order: bysource
     :show-inheritance:
@@ -297,7 +297,7 @@ Client TCP
 
 Client TLS
 ^^^^^^^^^^
-.. autoclass:: amodbus.client.AsyncModbusTlsClient
+.. autoclass:: amodbus.client.ModbusTlsClient
     :members:
     :member-order: bysource
     :show-inheritance:
@@ -309,7 +309,7 @@ Client TLS
 
 Client UDP
 ^^^^^^^^^^
-.. autoclass:: amodbus.client.AsyncModbusUdpClient
+.. autoclass:: amodbus.client.ModbusUdpClient
     :members:
     :member-order: bysource
     :show-inheritance:

--- a/examples/client_async.py
+++ b/examples/client_async.py
@@ -54,7 +54,7 @@ def setup_async_client(description: str | None = None, cmdline: str | None = Non
     _logger.info("### Create client object")
     client: modbusClient.ModbusBaseClient | None = None
     if args.comm == "tcp":
-        client = modbusClient.AsyncModbusTcpClient(
+        client = modbusClient.ModbusTcpClient(
             args.host,
             port=args.port,  # on which port
             # Common optional parameters:
@@ -66,7 +66,7 @@ def setup_async_client(description: str | None = None, cmdline: str | None = Non
             #    source_address=("localhost", 0),
         )
     elif args.comm == "udp":
-        client = modbusClient.AsyncModbusUdpClient(
+        client = modbusClient.ModbusUdpClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -77,7 +77,7 @@ def setup_async_client(description: str | None = None, cmdline: str | None = Non
             #    source_address=None,
         )
     elif args.comm == "serial":
-        client = modbusClient.AsyncModbusSerialClient(
+        client = modbusClient.ModbusSerialClient(
             args.port,
             # Common optional parameters:
             #    framer=FramerType.RTU,
@@ -91,7 +91,7 @@ def setup_async_client(description: str | None = None, cmdline: str | None = Non
             #    handle_local_echo=False,
         )
     elif args.comm == "tls":
-        client = modbusClient.AsyncModbusTlsClient(
+        client = modbusClient.ModbusTlsClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -99,7 +99,7 @@ def setup_async_client(description: str | None = None, cmdline: str | None = Non
             timeout=args.timeout,
             #    retries=3,
             # TLS setup parameters
-            sslctx=modbusClient.AsyncModbusTlsClient.generate_ssl(
+            sslctx=modbusClient.ModbusTlsClient.generate_ssl(
                 certfile=helper.get_certificate("crt"),
                 keyfile=helper.get_certificate("key"),
                 #    password="none",

--- a/examples/client_performance.py
+++ b/examples/client_performance.py
@@ -17,7 +17,7 @@ import asyncio
 import time
 
 from amodbus import FramerType
-from amodbus.client import AsyncModbusSerialClient, ModbusSerialClient
+from amodbus.client import ModbusSerialClient
 
 LOOP_COUNT = 1000
 REGISTER_COUNT = 10
@@ -51,7 +51,7 @@ def run_sync_client_test():
 async def run_async_client_test():
     """Run async client."""
     print("--- Testing async client v3.4.1")
-    client = AsyncModbusSerialClient(
+    client = ModbusSerialClient(
         "/dev/ttys007",
         framer=FramerType.RTU,
         baudrate=9600,

--- a/examples/custom_msg.py
+++ b/examples/custom_msg.py
@@ -14,7 +14,7 @@ import asyncio
 import struct
 
 from amodbus import FramerType
-from amodbus.client import AsyncModbusTcpClient as ModbusClient
+from amodbus.client import ModbusTcpClient as ModbusClient
 from amodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,

--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -110,15 +110,15 @@ class ClientTester:  # pylint: disable=too-few-public-methods
         global test_port  # pylint: disable=global-statement
         self.comm = comm
         host = NULLMODEM_HOST
-        self.client: modbusClient.AsyncModbusTcpClient | modbusClient.AsyncModbusSerialClient
+        self.client: modbusClient.ModbusTcpClient | modbusClient.ModbusSerialClient
         if comm == CommType.TCP:
-            self.client = modbusClient.AsyncModbusTcpClient(
+            self.client = modbusClient.ModbusTcpClient(
                 host,
                 port=test_port,
             )
         elif comm == CommType.SERIAL:
             host = f"{NULLMODEM_HOST}:{test_port}"
-            self.client = modbusClient.AsyncModbusSerialClient(
+            self.client = modbusClient.ModbusSerialClient(
                 host,
             )
         else:

--- a/examples/simple_async_client.py
+++ b/examples/simple_async_client.py
@@ -23,7 +23,7 @@ async def run_async_simple_client(comm, host, port, framer=FramerType.SOCKET):
     print("get client")
     client: ModbusClient.ModbusBaseClient
     if comm == "tcp":
-        client = ModbusClient.AsyncModbusTcpClient(
+        client = ModbusClient.ModbusTcpClient(
             host,
             port=port,
             framer=framer,
@@ -32,7 +32,7 @@ async def run_async_simple_client(comm, host, port, framer=FramerType.SOCKET):
             # source_address=("localhost", 0),
         )
     elif comm == "udp":
-        client = ModbusClient.AsyncModbusUdpClient(
+        client = ModbusClient.ModbusUdpClient(
             host,
             port=port,
             framer=framer,
@@ -41,7 +41,7 @@ async def run_async_simple_client(comm, host, port, framer=FramerType.SOCKET):
             # source_address=None,
         )
     elif comm == "serial":
-        client = ModbusClient.AsyncModbusSerialClient(
+        client = ModbusClient.ModbusSerialClient(
             port,
             framer=framer,
             # timeout=10,

--- a/examples/simulator.py
+++ b/examples/simulator.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 
 from amodbus import FramerType
-from amodbus.client import AsyncModbusTcpClient
+from amodbus.client import ModbusTcpClient
 from amodbus.datastore import ModbusSimulatorContext
 from amodbus.server import ModbusSimulatorServer, get_simulator_commandline
 
@@ -68,7 +68,7 @@ async def run_simulator():
     await task.run_forever(only_start=True)
 
     _logger.info("### start client")
-    client = AsyncModbusTcpClient(
+    client = ModbusTcpClient(
         "127.0.0.1",
         port=5020,
         framer=FramerType.SOCKET,

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -387,10 +387,10 @@ class TestClientBase:
     @pytest.mark.parametrize(
         ("type_args", "clientclass"),
         [
-            # TBD ("serial", lib_client.AsyncModbusSerialClient),
-            ("tcp", lib_client.AsyncModbusTcpClient),
-            ("tls", lib_client.AsyncModbusTlsClient),
-            ("udp", lib_client.AsyncModbusUdpClient),
+            # TBD ("serial", lib_client.ModbusSerialClient),
+            ("tcp", lib_client.ModbusTcpClient),
+            ("tls", lib_client.ModbusTlsClient),
+            ("udp", lib_client.ModbusUdpClient),
         ],
     )
     @pytest.mark.parametrize("test_default", [True, False])
@@ -448,7 +448,7 @@ class TestClientBase:
 
     async def test_client_connection_made(self):
         """Test protocol made connection."""
-        client = lib_client.AsyncModbusTcpClient("127.0.0.1")
+        client = lib_client.ModbusTcpClient("127.0.0.1")
         assert not client.connected
 
         transport = mock.AsyncMock()
@@ -480,11 +480,11 @@ class TestClientBase:
 
     async def test_client_protocol(self):
         """Test protocol made connection."""
-        client = lib_client.AsyncModbusTcpClient("127.0.0.1")
+        client = lib_client.ModbusTcpClient("127.0.0.1")
         client.ctx.loop = mock.Mock()
         client.ctx.callback_connected()
         client.ctx.callback_disconnected(None)
-        client = lib_client.AsyncModbusTcpClient("127.0.0.1", trace_connect=client.ctx.dummy_trace_connect)
+        client = lib_client.ModbusTcpClient("127.0.0.1", trace_connect=client.ctx.dummy_trace_connect)
         client.ctx.loop = mock.Mock()
         client.ctx.callback_connected()
         client.ctx.callback_disconnected(None)
@@ -511,12 +511,12 @@ class TestClientBase:
 
     async def test_client_tls_connect(self):
         """Test the tls client connection method."""
-        sslctx = lib_client.AsyncModbusTlsClient.generate_ssl(
+        sslctx = lib_client.ModbusTlsClient.generate_ssl(
             certfile=get_certificate("crt"),
             keyfile=get_certificate("key"),
         )
         with mock.patch.object(ssl.SSLSocket, "connect") as mock_method:
-            client = lib_client.AsyncModbusTlsClient(
+            client = lib_client.ModbusTlsClient(
                 "127.0.0.1",
                 sslctx=sslctx,
             )
@@ -526,16 +526,16 @@ class TestClientBase:
 
         with mock.patch.object(socket, "create_connection") as mock_method:
             mock_method.side_effect = OSError()
-            client = lib_client.AsyncModbusTlsClient("127.0.0.1", sslctx=sslctx)
+            client = lib_client.ModbusTlsClient("127.0.0.1", sslctx=sslctx)
             assert not await client.connect()
 
     @pytest.mark.parametrize(
         ("client_class"),
         [
-            lib_client.AsyncModbusSerialClient,
-            lib_client.AsyncModbusTcpClient,
-            lib_client.AsyncModbusTlsClient,
-            lib_client.AsyncModbusUdpClient,
+            lib_client.ModbusSerialClient,
+            lib_client.ModbusTcpClient,
+            lib_client.ModbusTlsClient,
+            lib_client.ModbusUdpClient,
         ],
     )
     async def test_wrong_framer(self, client_class):
@@ -545,4 +545,4 @@ class TestClientBase:
 
     async def test_instance_serial(self):
         """Test instantiate."""
-        _client = lib_client.AsyncModbusSerialClient("port")
+        _client = lib_client.ModbusSerialClient("port")

--- a/test/server/test_server_asyncio.py
+++ b/test/server/test_server_asyncio.py
@@ -10,7 +10,7 @@ from unittest import mock
 import pytest
 
 from amodbus import FramerType
-from amodbus.client import AsyncModbusTcpClient
+from amodbus.client import ModbusTcpClient
 from amodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,
@@ -249,7 +249,7 @@ class TestAsyncioServer:
         addr = ("127.0.0.1", 25001)
         await self.start_server(serv_addr=addr)
         for _ in range(2048):
-            client = AsyncModbusTcpClient(addr[0], framer=FramerType.SOCKET, port=addr[1])
+            client = ModbusTcpClient(addr[0], framer=FramerType.SOCKET, port=addr[1])
             await client.connect()
             response = await client.read_coils(31, count=1, slave=1)
             assert not response.isError()

--- a/test/server/test_simulator.py
+++ b/test/server/test_simulator.py
@@ -7,7 +7,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from amodbus.client import AsyncModbusTcpClient
+from amodbus.client import ModbusTcpClient
 from amodbus.datastore import ModbusSimulatorContext
 from amodbus.datastore.simulator import Cell, CellType, Label
 from amodbus.server import ModbusSimulatorServer
@@ -543,7 +543,7 @@ class TestSimulator:
 
     async def test_simulator_server_end_to_end(self, simulator_server, use_port):
         """Test simulator server end to end."""
-        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
+        client = ModbusTcpClient(NULLMODEM_HOST, port=use_port)
         assert await client.connect()
         result = await client.read_holding_registers(16, count=1, slave=1)
         assert result.registers[0] == 3124
@@ -551,7 +551,7 @@ class TestSimulator:
 
     async def test_simulator_server_string(self, simulator_server, use_port):
         """Test simulator server end to end."""
-        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
+        client = ModbusTcpClient(NULLMODEM_HOST, port=use_port)
         assert await client.connect()
         result = await client.read_holding_registers(43, count=2, slave=1)
         assert result.registers[0] == int.from_bytes(bytes("St", "utf-8"), "big")


### PR DESCRIPTION
All clients are async now so the Async prefix is redundant.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
